### PR TITLE
Make description a text box

### DIFF
--- a/lib/screens/taskform_screen.dart
+++ b/lib/screens/taskform_screen.dart
@@ -50,10 +50,23 @@ class _TaskFormScreenState extends State<TaskFormScreen> {
                     return null;
                   },
                 ),
-                TextFormField(
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 15.0),
+                child: TextFormField(
                   controller: _descController,
-                  decoration:
-                      const InputDecoration(labelText: 'Task Description'),
+                  decoration: const InputDecoration(
+                    labelText: 'Task Description',
+                    hintText: 'Enter a detailed description...',
+                    alignLabelWithHint: true,
+                    border:
+                        OutlineInputBorder(), // Adds a border for a defined look
+                    contentPadding: EdgeInsets.symmetric(
+                        vertical: 15,
+                        horizontal: 12), // Adds padding inside the text field
+                  ),
+                  maxLines:
+                      6, // Provides a reasonable height for multi-line input
+                  minLines: 4, // Ensures the field has a minimum height
                   validator: (value) {
                     if (value == null || value.isEmpty) {
                       return "Description cannot be empty!";
@@ -61,6 +74,7 @@ class _TaskFormScreenState extends State<TaskFormScreen> {
                     return null;
                   },
                 ),
+              ),
                 // boolformfield for a bool value (hasDeadline)
                 // CheckboxListTile(value: hasDeadline, onChanged: (value)=>{
                 //   setState(() {

--- a/lib/screens/tasklist_screen.dart
+++ b/lib/screens/tasklist_screen.dart
@@ -73,7 +73,11 @@ class _TaskListScreenState extends State<TaskListScreen> {
             ),
             subtitle:
                 Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
-              Text(task.description),
+              Text(
+                task.description.length > 30
+                    ? '${task.description.substring(0, 30)}...'
+                    : task.description,
+              ),
               Row(children: [
                 if (task.hasDeadline)
                   Text(


### PR DESCRIPTION
### Related Issue  
Closes #71 

### Type of Change
Put `x` inside the square bracket to specify what type of change your PR is:  
- [x] Bug Fix  

### Description of Change  
Now the form has a proper text box for description and also the list tile shows only starting portion of the descp text followed by three dots to prevent overflow.



### Demo  
![image](https://github.com/user-attachments/assets/7dba26fa-8675-403b-9536-aa34efe7359c)
![image](https://github.com/user-attachments/assets/ebe1a9de-d71f-443b-a134-9a3179e4dd43)
