### PR TITLE
Added undo snackbar #41

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -73,21 +73,6 @@ class _HomeScreenState extends State<HomeScreen> {
         TaskStorage.saveTasks(tasks);
       }
     });
-
-    void _editTask(int index) async {
-      final newTask = await Navigator.push<Task>(
-        context,
-        MaterialPageRoute(
-          builder: (context) => TaskFormScreen(task: tasks[index]),
-        ),
-      );
-
-      if (newTask != null) {
-        tasks[index] = newTask;
-        setState(() {});
-        await TaskStorage.saveTasks(tasks);
-      }
-    }
   }
 
   void _editTask(int index) async {

--- a/lib/screens/tasklist_screen.dart
+++ b/lib/screens/tasklist_screen.dart
@@ -21,6 +21,9 @@ class TaskListScreen extends StatefulWidget {
 }
 
 class _TaskListScreenState extends State<TaskListScreen> {
+  int? deletedIndex;
+  Task? deletedTask;
+
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
@@ -54,11 +57,35 @@ class _TaskListScreenState extends State<TaskListScreen> {
                   onEdit: () => widget.onEdit(index),
                   onDelete: () async {
                     setState(() {
+                      deletedTask = widget.tasks[index];
+                      deletedIndex = index;
                       widget.tasks.removeAt(index);
                     });
-                    await TaskStorage.saveTasks(widget.tasks);
                     Navigator.of(context)
                         .pop(); // Close the dialog after deletion
+
+                    ScaffoldMessenger.of(context)
+                        .showSnackBar(
+                          SnackBar(
+                            content: const Text("Deleted accidentally?"),
+                            action: SnackBarAction(
+                              label: "Undo",
+                              onPressed: () {
+                                widget.tasks
+                                    .insert(deletedIndex!, deletedTask!);
+                                setState(() {});
+                              },
+                            ),
+                          ),
+                        )
+                        .closed
+                        .then(
+                      (value) async {
+                        if (value != SnackBarClosedReason.action) {
+                          await TaskStorage.saveTasks(widget.tasks);
+                        }
+                      },
+                    );
                   },
                   onClose: () => Navigator.of(context).pop(),
                 ),


### PR DESCRIPTION
### Related Issue  
Closes #41 

### Type of Change
Put `x` inside the square bracket to specify what type of change your PR is:  
- [x] New Feature

### Description of Change  
Adds an undo snackbar at bottom of the screen after deleting a task. 
For 'completed' action - the user can simply uncheck the task from the list.

### Implementation Details  
The task is temporarily deleted from the list and if the user does not click undo then the task is deleted from the storage too.

### Demo  

https://github.com/user-attachments/assets/1395237f-95ae-4d0c-972b-0dcc64470e20

