### PR TITLE
Fixed custom font working on dark theme #98

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,7 +48,11 @@ class _TasklyAppState extends State<TasklyApp> {
             primarySwatch: Colors.blue,
             fontFamily: 'Quicksand',
           ),
-          darkTheme: ThemeData.dark(),
+          darkTheme: ThemeData.dark().copyWith(
+            textTheme: ThemeData.dark().textTheme.apply(
+              fontFamily: 'Quicksand',
+            ),
+          ),
           themeMode: value.darkTheme ? ThemeMode.dark : ThemeMode.light,
           home: widget.isFirstTime ? const IntroScreen() : const HomeScreen(),
         ),


### PR DESCRIPTION
### Related Issue  
Closes #98 

### Type of Change
Put `x` inside the square bracket to specify what type of change your PR is:  
- [x] Bug Fix  

### Description of Change  
Now the custom font is there on both light and dark theme.

### Demo  
![image](https://github.com/user-attachments/assets/764e1e8a-865d-44c4-ac37-363ef52278f5)
