### PR TITLE
Theme data is saved locally for same theme on next app run #103

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,11 +28,12 @@ class TasklyApp extends StatefulWidget {
 class _TasklyAppState extends State<TasklyApp> {
   late ThemeProvider themeProvider;
 
+
   @override
   void initState() {
     super.initState();
     themeProvider =
-        ThemeProvider(dark: Theme.of(context).brightness == Brightness.dark);
+        ThemeProvider();
     SpeechService.intialize();
   }
 

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -1,14 +1,26 @@
 import 'package:flutter/material.dart';
+import 'package:taskly/themeData_storage.dart';
 
 class ThemeProvider extends ChangeNotifier {
-  bool _dark = false;
+  bool _dark = false; // Default to false
 
-  ThemeProvider({bool? dark}) : _dark = dark ?? false;
+  ThemeProvider() {
+    // Fetch stored theme asynchronously and update
+    _loadTheme();
+  }
+
+  // Asynchronously load theme
+  Future<void> _loadTheme() async {
+    bool storedTheme = await ThemeStorage.loadtheme(); // Load theme
+    _dark = storedTheme; // Update the value
+    notifyListeners(); // Notify UI
+  }
 
   bool get darkTheme => _dark;
 
   set darkTheme(bool value) {
     _dark = value;
+    ThemeStorage.savetheme(value); // Save updated value
     notifyListeners();
   }
 }

--- a/lib/themeData_storage.dart
+++ b/lib/themeData_storage.dart
@@ -1,0 +1,17 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ThemeStorage {
+  static const String _themeKey = 'theme';
+
+  static Future<void> savetheme(bool isDark) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_themeKey, isDark.toString());
+  }
+
+  static Future<bool> loadtheme() async {
+    final prefs = await SharedPreferences.getInstance();
+    String? encodedthemes = prefs.getString(_themeKey);
+
+    return encodedthemes == 'true';
+  }
+}


### PR DESCRIPTION
### Related Issue  
Closes #103 

### Type of Change
Put `x` inside the square bracket to specify what type of change your PR is:  
- [x] Bug Fix  

### Description of Change  
Now the Boolean value of theme data "isDark" is being saved locally and so once the user has switched to dark theme, the app will start with the dark theme only from the next app run until theme switch is again changed.
