### PR TITLE
deadline late date bug fixed

### DIFF
--- a/lib/screens/taskform_screen.dart
+++ b/lib/screens/taskform_screen.dart
@@ -203,7 +203,7 @@ class _TaskFormScreenState extends State<TaskFormScreen> {
               context: context,
               initialDate: DateTime.now(),
               firstDate: DateTime.now(),
-              lastDate: DateTime(2025),
+              lastDate: DateTime.now().add(const Duration(days: 365)),
             );
             if (selectedDate != null) {
               setState(() {


### PR DESCRIPTION
### Related Issue  
Closes #150

### Type of Change
Put `x` inside the square bracket to specify what type of change your PR is:  
- [x] Bug Fix  

### Description of Change  
This bug was already fixed earlier by #121 but it is regenerated by some contributions. 
Solution: Changed the last date of date picker from first date of 2025 to next 1 year of current date. 
